### PR TITLE
V2: Amphora 5.x Compatibility Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - '6'
+  - '8'

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# clay-utils
+# clayutils
 
 [![Build Status](https://travis-ci.org/clay/clayutils.svg?branch=master)](https://travis-ci.org/clay/clayutils)
 [![Coverage Status](https://coveralls.io/repos/github/clay/clayutils/badge.svg?branch=master)](https://coveralls.io/github/clay/clayutils?branch=master)
 
-Utility functions for working with Clay
+Utility functions for working with Clay.
+
+Version 2.x is compatible with Amphora 5.x. For pre-5.x utilities refer to 1.x releases.
 
 # Installation
 
 ```
-npm install --save clay-utils
+npm install --save clayutils
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# clayutils
+# clay-utils
 
 [![Build Status](https://travis-ci.org/clay/clayutils.svg?branch=master)](https://travis-ci.org/clay/clayutils)
 [![Coverage Status](https://coveralls.io/repos/github/clay/clayutils/badge.svg?branch=master)](https://coveralls.io/github/clay/clayutils?branch=master)
@@ -8,7 +8,7 @@ Utility functions for working with Clay
 # Installation
 
 ```
-npm install --save clayutils
+npm install --save clay-utils
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -26,4 +26,8 @@ npm install --save clay-utils
 * **isList** [(code|tests|docs)](https://github.com/clay/clayutils/tree/master/lib/isList)
 * **isPage** [(code|tests|docs)](https://github.com/clay/clayutils/tree/master/lib/isPage)
 * **isUser** [(code|tests|docs)](https://github.com/clay/clayutils/tree/master/lib/isUser)
+* **jsonPrefixToSlug** [(code|tests|docs)](https://github.com/clay/clayutils/tree/master/lib/jsonPrefixToSlug)
+* **jsonSlugToPrefix** [(code|tests|docs)](https://github.com/clay/clayutils/tree/master/lib/jsonSlugToPrefix)
 * **replaceVersion** [(code|tests|docs)](https://github.com/clay/clayutils/tree/master/lib/replaceVersion)
+* **uriPrefixToSlug** [(code|tests|docs)](https://github.com/clay/clayutils/tree/master/lib/uriPrefixToSlug)
+* **uriSlugToPrefix** [(code|tests|docs)](https://github.com/clay/clayutils/tree/master/lib/uriSlugToPrefix)

--- a/docs/readme.hbs
+++ b/docs/readme.hbs
@@ -1,14 +1,16 @@
-# clay-utils
+# clayutils
 
 [![Build Status](https://travis-ci.org/clay/clayutils.svg?branch=master)](https://travis-ci.org/clay/clayutils)
 [![Coverage Status](https://coveralls.io/repos/github/clay/clayutils/badge.svg?branch=master)](https://coveralls.io/github/clay/clayutils?branch=master)
 
-Utility functions for working with Clay
+Utility functions for working with Clay.
+
+Version 2.x is compatible with Amphora 5.x. For pre-5.x utilities refer to 1.x releases.
 
 # Installation
 
 ```
-npm install --save clay-utils
+npm install --save clayutils
 ```
 
 ---

--- a/index.js
+++ b/index.js
@@ -11,3 +11,7 @@ module.exports.isPage = require('./lib/isPage');
 module.exports.isList = require('./lib/isList');
 module.exports.isUser = require('./lib/isUser');
 module.exports.replaceVersion = require('./lib/replaceVersion');
+module.exports.uriPrefixToSlug = require('./lib/uriPrefixToSlug');
+module.exports.uriSlugToPrefix = require('./lib/uriSlugToPrefix');
+module.exports.jsonPrefixToSlug = require('./lib/jsonPrefixToSlug');
+module.exports.jsonSlugToPrefix = require('./lib/jsonSlugToPrefix');

--- a/lib/getComponentInstance/index.js
+++ b/lib/getComponentInstance/index.js
@@ -11,7 +11,7 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /\/components\/.+?\/instances\/([^\.@]+)/.exec(uri);
+  const result = /\/_components\/.+?\/instances\/([^\.@]+)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getComponentInstance/index.test.js
+++ b/lib/getComponentInstance/index.test.js
@@ -6,23 +6,23 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('getComponentInstance', () => {
   it('gets instance from uri', function () {
-    expect(fn('/components/base/instances/0')).to.equal('0');
+    expect(fn('/_components/base/instances/0')).to.equal('0');
   });
 
   it('gets instance from uri with extension', function () {
-    expect(fn('/components/base/instances/0.html')).to.equal('0');
+    expect(fn('/_components/base/instances/0.html')).to.equal('0');
   });
 
   it('gets instance from uri with version', function () {
-    expect(fn('/components/base/instances/0@published')).to.equal('0');
+    expect(fn('/_components/base/instances/0@published')).to.equal('0');
   });
 
   it('gets instance from full uri', function () {
-    expect(fn('nymag.com/press/components/base/instances/foobarbaz@published')).to.equal('foobarbaz');
+    expect(fn('nymag.com/press/_components/base/instances/foobarbaz@published')).to.equal('foobarbaz');
   });
 
   it('CANNOT get instance from default uri', function () {
-    expect(fn('/components/base')).to.not.equal('0');
+    expect(fn('/_components/base')).to.not.equal('0');
   });
 
   it('throws an error if argument passed in is not a String', () => {

--- a/lib/getComponentName/index.js
+++ b/lib/getComponentName/index.js
@@ -13,7 +13,7 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /components\/(.+?)[\/\.]/.exec(uri) || /components\/(.*)/.exec(uri);
+  const result = /_components\/(.+?)[\/\.]/.exec(uri) || /_components\/(.*)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getComponentName/index.test.js
+++ b/lib/getComponentName/index.test.js
@@ -6,24 +6,24 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('getComponentName', () => {
   it('gets name from default uri', function () {
-    expect(fn('/components/base')).to.equal('base');
+    expect(fn('/_components/base')).to.equal('base');
   });
 
   it('gets name from instance uri', function () {
-    expect(fn('/components/base/instances/0')).to.equal('base');
+    expect(fn('/_components/base/instances/0')).to.equal('base');
   });
 
   it('gets name from versioned uri', function () {
-    expect(fn('/components/base/instances/0@published')).to.equal('base');
+    expect(fn('/_components/base/instances/0@published')).to.equal('base');
   });
 
   it('gets name from uri with extension', function () {
-    expect(fn('/components/base.html')).to.equal('base');
-    expect(fn('/components/base.json')).to.equal('base');
+    expect(fn('/_components/base.html')).to.equal('base');
+    expect(fn('/_components/base.json')).to.equal('base');
   });
 
   it('gets name from full uri', function () {
-    expect(fn('nymag.com/press/components/base/instances/foobarbaz@published')).to.equal('base');
+    expect(fn('nymag.com/press/_components/base/instances/foobarbaz@published')).to.equal('base');
   });
 
   it('throws an error if argument passed in is not a String', () => {

--- a/lib/getComponentVersion/index.js
+++ b/lib/getComponentVersion/index.js
@@ -11,7 +11,7 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /\/components\/.+?@(.+)/.exec(uri);
+  const result = /\/_components\/.+?@(.+)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getComponentVersion/index.test.js
+++ b/lib/getComponentVersion/index.test.js
@@ -6,16 +6,16 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('getComponentVersion', () => {
   it('gets version from instance uri', () => {
-    expect(fn('/components/foo/instances/bar@published')).to.equal('published');
+    expect(fn('/_components/foo/instances/bar@published')).to.equal('published');
   });
 
   it('gets version from default uri', () => {
-    expect(fn('/components/base@published')).to.equal('published');
+    expect(fn('/_components/base@published')).to.equal('published');
   });
 
   it('returns null if no version', () => {
-    expect(fn('/components/foo/instances/bar')).to.equal(null);
-    expect(fn('/components/base')).to.equal(null);
+    expect(fn('/_components/foo/instances/bar')).to.equal(null);
+    expect(fn('/_components/base')).to.equal(null);
   });
 
   it('throws an error if argument passed in is not a String', () => {

--- a/lib/getListInstance/index.js
+++ b/lib/getListInstance/index.js
@@ -11,7 +11,7 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /\/lists\/(.*)/.exec(uri);
+  const result = /\/_lists\/(.*)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getListInstance/index.test.js
+++ b/lib/getListInstance/index.test.js
@@ -7,12 +7,12 @@ const name = __filename.split('/').pop().split('.').shift(),
 describe('getListInstance', function () {
 
   it('gets instance from uri', function () {
-    expect(fn('/lists/foo')).to.equal('foo');
+    expect(fn('/_lists/foo')).to.equal('foo');
   });
 
   it('CANNOT get instance from a non-list uri', function () {
-    expect(fn('/components/foo/instances/0')).to.equal(null);
-    expect(fn('/pages/foo')).to.equal(null);
+    expect(fn('/_components/foo/instances/0')).to.equal(null);
+    expect(fn('/_pages/foo')).to.equal(null);
   });
 
   it('throws an error if argument passed in is not a String', function () {

--- a/lib/getPageInstance/index.js
+++ b/lib/getPageInstance/index.js
@@ -11,7 +11,7 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /\/pages\/(.*)/.exec(uri);
+  const result = /\/_pages\/(.*)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getPageInstance/index.test.js
+++ b/lib/getPageInstance/index.test.js
@@ -6,19 +6,19 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('getPageInstance', () => {
   it('gets instance from uri', function () {
-    expect(fn('/pages/foobar')).to.equal('foobar');
+    expect(fn('/_pages/foobar')).to.equal('foobar');
   });
 
   it('gets instance from uri with version', function () {
-    expect(fn('/pages/foobar@published')).to.equal('foobar@published');
+    expect(fn('/_pages/foobar@published')).to.equal('foobar@published');
   });
 
   it('gets instance from full uri', function () {
-    expect(fn('nymag.com/scienceofus/pages/foobarbaz@published')).to.equal('foobarbaz@published');
+    expect(fn('nymag.com/scienceofus/_pages/foobarbaz@published')).to.equal('foobarbaz@published');
   });
 
   it('CANNOT get instance from a non-page uri', function () {
-    expect(fn('/components/base/instances/0')).to.not.equal('0');
+    expect(fn('/_components/base/instances/0')).to.not.equal('0');
   });
 
   it('throws an error if argument passed in is not a String', () => {

--- a/lib/getPageVersion/index.js
+++ b/lib/getPageVersion/index.js
@@ -11,7 +11,7 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /\/pages\/.+?@(.+)/.exec(uri);
+  const result = /\/_pages\/.+?@(.+)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getPageVersion/index.test.js
+++ b/lib/getPageVersion/index.test.js
@@ -6,11 +6,11 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('getPageVersion', () => {
   it('gets version from instance uri', () => {
-    expect(fn('/pages/foo@published')).to.equal('published');
+    expect(fn('/_pages/foo@published')).to.equal('published');
   });
 
   it('returns null if no version', () => {
-    expect(fn('/pages/foo')).to.equal(null);
+    expect(fn('/_pages/foo')).to.equal(null);
   });
 
   it('throws an error if argument passed in is not a String', () => {

--- a/lib/isComponent/index.js
+++ b/lib/isComponent/index.js
@@ -10,5 +10,5 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  return uri.toLowerCase().indexOf('/components/') > -1;
+  return uri.toLowerCase().indexOf('/_components/') > -1;
 };

--- a/lib/isComponent/index.test.js
+++ b/lib/isComponent/index.test.js
@@ -6,11 +6,11 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('isComponent', () => {
   it('returns true if component reference', () => {
-    expect(fn('domain.com/components/foo')).to.equal(true);
+    expect(fn('domain.com/_components/foo')).to.equal(true);
   });
 
   it('returns true if component instance reference', () => {
-    expect(fn('domain.com/components/foo/instances/bar')).to.equal(true);
+    expect(fn('domain.com/_components/foo/instances/bar')).to.equal(true);
   });
 
   it('throws an error if the URI passed in is not a string', () => {
@@ -22,7 +22,7 @@ describe('isComponent', () => {
   });
 
   it('returns false if non-component reference', () => {
-    expect(fn('domain.com/users/foo')).to.equal(false);
-    expect(fn('domain.com/pages/foo')).to.equal(false);
+    expect(fn('domain.com/_users/foo')).to.equal(false);
+    expect(fn('domain.com/_pages/foo')).to.equal(false);
   });
 });

--- a/lib/isDefaultComponent/index.js
+++ b/lib/isDefaultComponent/index.js
@@ -11,5 +11,5 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  return !!uri.match(/\/components\/[A-Za-z0-9\-]+$/);
+  return !!uri.match(/\/_components\/[A-Za-z0-9\-]+$/);
 };

--- a/lib/isDefaultComponent/index.test.js
+++ b/lib/isDefaultComponent/index.test.js
@@ -6,11 +6,11 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('isDefaultComponent', () => {
   it('returns true if default component reference', () => {
-    expect(fn('domain.com/components/foo')).to.equal(true);
+    expect(fn('domain.com/_components/foo')).to.equal(true);
   });
 
   it('returns false if component instance reference', () => {
-    expect(fn('domain.com/components/foo/instances/bar')).to.equal(false);
+    expect(fn('domain.com/_components/foo/instances/bar')).to.equal(false);
   });
 
   it('throws an error if argument passed in is not a String', () => {
@@ -22,7 +22,7 @@ describe('isDefaultComponent', () => {
   });
 
   it('returns false if non-component reference', () => {
-    expect(fn('domain.com/users/foo')).to.equal(false);
-    expect(fn('domain.com/pages/foo')).to.equal(false);
+    expect(fn('domain.com/_users/foo')).to.equal(false);
+    expect(fn('domain.com/_pages/foo')).to.equal(false);
   });
 });

--- a/lib/isList/index.js
+++ b/lib/isList/index.js
@@ -11,5 +11,5 @@ const isUriStringCheck = require('../strCheck');
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
 
-  return uri.toLowerCase().indexOf('/lists/') > -1;
+  return uri.toLowerCase().indexOf('/_lists/') > -1;
 };

--- a/lib/isList/index.test.js
+++ b/lib/isList/index.test.js
@@ -6,7 +6,7 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('isList', () => {
   it('returns true if list reference', () => {
-    expect(fn('domain.com/lists/foo')).to.equal(true);
+    expect(fn('domain.com/_lists/foo')).to.equal(true);
   });
 
   it('throws an error if the URI passed in is not a string', () => {
@@ -18,9 +18,9 @@ describe('isList', () => {
   });
 
   it('returns false if non-list reference', () => {
-    expect(fn('domain.com/users/foo')).to.equal(false);
-    expect(fn('domain.com/pages/foo')).to.equal(false);
-    expect(fn('domain.com/components/foo')).to.equal(false);
-    expect(fn('domain.com/components/foo/instances/bar')).to.equal(false);
+    expect(fn('domain.com/_users/foo')).to.equal(false);
+    expect(fn('domain.com/_pages/foo')).to.equal(false);
+    expect(fn('domain.com/_components/foo')).to.equal(false);
+    expect(fn('domain.com/_components/foo/instances/bar')).to.equal(false);
   });
 });

--- a/lib/isPage/index.js
+++ b/lib/isPage/index.js
@@ -10,5 +10,5 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  return uri.toLowerCase().indexOf('/pages/') > -1;
+  return uri.toLowerCase().indexOf('/_pages/') > -1;
 };

--- a/lib/isPage/index.test.js
+++ b/lib/isPage/index.test.js
@@ -6,11 +6,11 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('isPage', () => {
   it('returns true if page reference', () => {
-    expect(fn('domain.com/pages/foo')).to.equal(true);
+    expect(fn('domain.com/_pages/foo')).to.equal(true);
   });
 
   it('returns true if page instance reference', () => {
-    expect(fn('nymag.com/scienceofus/pages/foobarbaz@published')).to.equal(true);
+    expect(fn('nymag.com/scienceofus/_pages/foobarbaz@published')).to.equal(true);
   });
 
   it('throws an error if the URI passed in is not a string', () => {
@@ -22,7 +22,7 @@ describe('isPage', () => {
   });
 
   it('returns false if non-page reference', () => {
-    expect(fn('domain.com/users/foo')).to.equal(false);
-    expect(fn('domain.com/components/foo')).to.equal(false);
+    expect(fn('domain.com/_users/foo')).to.equal(false);
+    expect(fn('domain.com/_components/foo')).to.equal(false);
   });
 });

--- a/lib/isUser/index.js
+++ b/lib/isUser/index.js
@@ -11,5 +11,5 @@ const isUriStringCheck = require('../strCheck');
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
 
-  return uri.toLowerCase().indexOf('/users/') > -1;
+  return uri.toLowerCase().indexOf('/_users/') > -1;
 };

--- a/lib/isUser/index.test.js
+++ b/lib/isUser/index.test.js
@@ -6,7 +6,7 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('isUser', () => {
   it('returns true if user reference', () => {
-    expect(fn('domain.com/users/foo')).to.equal(true);
+    expect(fn('domain.com/_users/foo')).to.equal(true);
   });
 
   it('throws an error if the URI passed in is not a string', () => {
@@ -18,9 +18,9 @@ describe('isUser', () => {
   });
 
   it('returns false if non-user reference', () => {
-    expect(fn('domain.com/lists/foo')).to.equal(false);
-    expect(fn('domain.com/pages/foo')).to.equal(false);
-    expect(fn('domain.com/components/foo')).to.equal(false);
-    expect(fn('domain.com/components/foo/instances/bar')).to.equal(false);
+    expect(fn('domain.com/_lists/foo')).to.equal(false);
+    expect(fn('domain.com/_pages/foo')).to.equal(false);
+    expect(fn('domain.com/_components/foo')).to.equal(false);
+    expect(fn('domain.com/_components/foo/instances/bar')).to.equal(false);
   });
 });

--- a/lib/jsonPrefixToSlug/README.md
+++ b/lib/jsonPrefixToSlug/README.md
@@ -17,13 +17,13 @@ jsonPrefixToSlug(
   '{"layout": "cool.com/ref/path/_components/foo", "main": "cool.com/ref/path/_components/bad"}',
   locals.site
 )
-//=> '{"layout": "cool/_components/foo", "main": "cool/_components/bad"}',
+//=> '{"layout": "cool/_components/foo", "main": "cool/_components/bad"}'
 
 jsonPrefixToSlug(
   '{"child": { "_ref": "cool.com/ref/path/_components/foo" }, "prop": "value"}',
   locals.site,
   true
 )
-//=> '{"child": { "_ref": "cool/_components/foo" }, "prop": "value"}',
+//=> '{"child": { "_ref": "cool/_components/foo" }, "prop": "value"}'
 
 ```

--- a/lib/jsonPrefixToSlug/README.md
+++ b/lib/jsonPrefixToSlug/README.md
@@ -1,0 +1,29 @@
+### jsonPrefixToSlug
+
+Update stringified JSON to swap site prefixes for site slugs for each referenced component's uri
+
+#### Params
+
+* `json` _string_
+* `site` _object_
+* `ref`  _boolean_
+
+**Returns** _string|null_
+
+#### Example
+
+```js
+jsonPrefixToSlug(
+  '{"layout": "cool.com/ref/path/_components/foo", "main": "cool.com/ref/path/_components/bad"}',
+  locals.site
+)
+//=> '{"layout": "cool/_components/foo", "main": "cool/_components/bad"}',
+
+jsonPrefixToSlug(
+  '{"child": { "_ref": "cool.com/ref/path/_components/foo" }, "prop": "value"}',
+  locals.site,
+  true
+)
+//=> '{"child": { "_ref": "cool/_components/foo" }, "prop": "value"}',
+
+```

--- a/lib/jsonPrefixToSlug/index.js
+++ b/lib/jsonPrefixToSlug/index.js
@@ -12,12 +12,12 @@ const isUriStringCheck = require('../strCheck');
  * @return {String}
  */
 module.exports = function (json, site, ref = false) {
-  var { slug, host, path } = site,
+  var { slug, host, path, prefix } = site,
     sitePrefix, prefixString, replaceString, searchRegex;
 
   isUriStringCheck.strCheck(json);
 
-  sitePrefix = path && path.length > 1 ? `${host}${path}` : host;
+  sitePrefix = prefix || path && path.length > 1 ? `${host}${path}` : host;
   prefixString = `${ref ? '"_ref":' : '' }"${sitePrefix}/_components/`;
   replaceString = `${ref ? '"_ref":' : '' }"${slug}/_components/`;
   searchRegex = new RegExp(prefixString, 'g');

--- a/lib/jsonPrefixToSlug/index.js
+++ b/lib/jsonPrefixToSlug/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const isUriStringCheck = require('../strCheck');
+
+/**
+ * Given stringified JSON, swap out the site's url-patterned prefix for
+ * the site's slug
+ *
+ * @param  {String}  json
+ * @param  {Object}  site
+ * @param  {Boolean} [ref=false]
+ * @return {String}
+ */
+module.exports = function (json, site, ref = false) {
+  var { slug, host, path } = site,
+    sitePrefix, prefixString, replaceString, searchRegex;
+
+  isUriStringCheck.strCheck(json);
+
+  sitePrefix = path && path.length > 1 ? `${host}${path}` : host;
+  prefixString = `${ref ? '"_ref":' : '' }"${sitePrefix}/_components/`;
+  replaceString = `${ref ? '"_ref":' : '' }"${slug}/_components/`;
+  searchRegex = new RegExp(prefixString, 'g');
+  return json.replace(searchRegex, replaceString);
+};

--- a/lib/jsonPrefixToSlug/index.test.js
+++ b/lib/jsonPrefixToSlug/index.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const name = __filename.split('/').pop().split('.').shift(),
+  fn = require('./' + name),
+  expect = require('chai').expect,
+  site = {
+    slug: 'domain',
+    host: 'domain.com',
+    path: '/path'
+  },
+  pageJson = JSON.stringify({
+    layout: 'domain.com/path/_components/two-column-layout/instances/index',
+    url: 'http://domain.com/path/foobarbaz.html',
+    main: [
+      'domain.com/path/_components/newsfeed/instances/index'
+    ]
+  }),
+  cmptJson = JSON.stringify({
+    title: 'Cool Title',
+    image: 'http://domain.com/path/some-img.png',
+    content: [{
+      _ref: 'domain.com/path/_components/foo/instances/foo'
+    },
+    {
+      _ref: 'domain.com/path/_components/bar/instances/bar'
+    }],
+    foobarInstance: {
+      _ref: 'domain.com/path/_components/foobar/instances/foobar'
+    }
+  }),
+  expectedPage = JSON.stringify({
+    layout: 'domain/_components/two-column-layout/instances/index',
+    url: 'http://domain.com/path/foobarbaz.html',
+    main: [
+      'domain/_components/newsfeed/instances/index'
+    ]
+  }),
+  expectedCmpt = JSON.stringify({
+    title: 'Cool Title',
+    image: 'http://domain.com/path/some-img.png',
+    content: [{
+      _ref: 'domain/_components/foo/instances/foo'
+    },
+    {
+      _ref: 'domain/_components/bar/instances/bar'
+    }],
+    foobarInstance: {
+      _ref: 'domain/_components/foobar/instances/foobar'
+    }
+  });
+
+describe('jsonPrefixToSlug', () => {
+  it('swaps the prefix for the slug on when not referenced with "_ref"', function () {
+    expect(fn(pageJson, site)).to.equal(expectedPage);
+  });
+
+  it('does not affect non-component reference properties (like page url)', function () {
+    expect(JSON.parse(fn(pageJson, site)).url).to.equal('http://domain.com/path/foobarbaz.html');
+  });
+
+  it('swaps the prefix for the slug for referenced components', function () {
+    expect(fn(cmptJson, site, true)).to.equal(expectedCmpt);
+  });
+
+  it('does not affect non-component reference properties', function () {
+    expect(JSON.parse(fn(cmptJson, site)).image).to.equal('http://domain.com/path/some-img.png');
+  });
+
+  it('throws if the JSON argument is not a string', () => {
+    const result = () => fn(1);
+
+    expect(result).to.throw('Argument must be a string, not number');
+  });
+});

--- a/lib/jsonPrefixToSlug/index.test.js
+++ b/lib/jsonPrefixToSlug/index.test.js
@@ -65,4 +65,14 @@ describe('jsonPrefixToSlug', () => {
   it('does not affect non-component reference properties', function () {
     expect(JSON.parse(fn(cmptJson, site)).image).to.equal('http://domain.com/path/some-img.png');
   });
+
+  it('works when no path is defined', function () {
+    var newSite = {
+      slug: 'domain',
+      host: 'domain.com'
+    };
+
+    expect(JSON.parse(fn(pageJson, newSite)).url).to.equal('http://domain.com/path/foobarbaz.html');
+    expect(JSON.parse(fn(cmptJson, newSite)).image).to.equal('http://domain.com/path/some-img.png');
+  });
 });

--- a/lib/jsonSlugToPrefix/README.md
+++ b/lib/jsonSlugToPrefix/README.md
@@ -1,0 +1,28 @@
+### jsonSlugToPrefix
+
+Update stringified JSON to swap site slug for site prefix for each referenced component's uri. Returns a function which then accepts the stringified JSON. Best when used as the `.then` following a read from the DB before parsing the response.
+
+#### Params
+
+* `site` _object_
+* `ref` _boolean_
+
+**Returns** _function_
+
+#### Example
+
+```js
+db.get(uri)
+  .then(jsonSlugToPrefix(site)) // Assuming '{"layout": "cool/_components/foo", "main": "cool/_components/bad"}',
+  .then(JSON.parse)
+  ...
+
+//=> '{"layout": "cool.com/ref/path/_components/foo", "main": "cool.com/ref/path/_components/bad"}',
+
+db.get(uri)
+  .then(jsonSlugToPrefix(site)) // Assuming '{"child": { "_ref": "cool/_components/foo" }, "prop": "value"}',
+  .then(JSON.parse)
+  ...
+
+//=> '{"child": { "_ref": "cool.com/ref/path/_components/foo" }, "prop": "value"}',
+```

--- a/lib/jsonSlugToPrefix/index.js
+++ b/lib/jsonSlugToPrefix/index.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const isUriStringCheck = require('../strCheck');
+
+/**
+ * Given stringified JSON, conver the site's slug
+ * to the url-patterned site prefix
+ *
+ * @param  {Object} site
+ * @param  {String} ref
+ * @return {Function}
+ */
+module.exports = function (site, ref = false) {
+  return function (json) {
+    var { slug, host, path } = site,
+      sitePrefix, prefixString, searchString, searchRegex;
+
+    isUriStringCheck.strCheck(json);
+
+    sitePrefix = path && path.length > 1 ? `${host}${path}` : host;
+    prefixString = `${ref ? '"_ref":' : '' }"${sitePrefix}/_components/`;
+    searchString = `${ref ? '"_ref":' : '' }"${slug}/_components/`;
+    searchRegex = new RegExp(searchString, 'g');
+    return json.replace(searchRegex, prefixString);
+  };
+};

--- a/lib/jsonSlugToPrefix/index.js
+++ b/lib/jsonSlugToPrefix/index.js
@@ -12,12 +12,12 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (site, ref = false) {
   return function (json) {
-    var { slug, host, path } = site,
+    var { slug, host, path, prefix } = site,
       sitePrefix, prefixString, searchString, searchRegex;
 
     isUriStringCheck.strCheck(json);
 
-    sitePrefix = path && path.length > 1 ? `${host}${path}` : host;
+    sitePrefix = prefix || path && path.length > 1 ? `${host}${path}` : host;
     prefixString = `${ref ? '"_ref":' : '' }"${sitePrefix}/_components/`;
     searchString = `${ref ? '"_ref":' : '' }"${slug}/_components/`;
     searchRegex = new RegExp(searchString, 'g');

--- a/lib/jsonSlugToPrefix/index.test.js
+++ b/lib/jsonSlugToPrefix/index.test.js
@@ -8,14 +8,14 @@ const name = __filename.split('/').pop().split('.').shift(),
     host: 'domain.com',
     path: '/path'
   },
-  pageJson = JSON.stringify({
+  expectedPage = JSON.stringify({
     layout: 'domain.com/path/_components/two-column-layout/instances/index',
     url: 'http://domain.com/path/foobarbaz.html',
     main: [
       'domain.com/path/_components/newsfeed/instances/index'
     ]
   }),
-  cmptJson = JSON.stringify({
+  expectedCmpt = JSON.stringify({
     title: 'Cool Title',
     image: 'http://domain.com/path/some-img.png',
     content: [{
@@ -28,14 +28,14 @@ const name = __filename.split('/').pop().split('.').shift(),
       _ref: 'domain.com/path/_components/foobar/instances/foobar'
     }
   }),
-  expectedPage = JSON.stringify({
+  pageJson = JSON.stringify({
     layout: 'domain/_components/two-column-layout/instances/index',
     url: 'http://domain.com/path/foobarbaz.html',
     main: [
       'domain/_components/newsfeed/instances/index'
     ]
   }),
-  expectedCmpt = JSON.stringify({
+  cmptJson = JSON.stringify({
     title: 'Cool Title',
     image: 'http://domain.com/path/some-img.png',
     content: [{
@@ -49,20 +49,20 @@ const name = __filename.split('/').pop().split('.').shift(),
     }
   });
 
-describe('jsonPrefixToSlug', () => {
-  it('swaps the prefix for the slug on when not referenced with "_ref"', function () {
-    expect(fn(pageJson, site)).to.equal(expectedPage);
+describe('jsonSlugToPrefix', () => {
+  it('swaps the slug for the prefix on when not referenced with "_ref"', function () {
+    expect(fn(site)(pageJson)).to.equal(expectedPage);
   });
 
   it('does not affect non-component reference properties (like page url)', function () {
-    expect(JSON.parse(fn(pageJson, site)).url).to.equal('http://domain.com/path/foobarbaz.html');
+    expect(JSON.parse(fn(site)(pageJson)).url).to.equal('http://domain.com/path/foobarbaz.html');
   });
 
   it('swaps the prefix for the slug for referenced components', function () {
-    expect(fn(cmptJson, site, true)).to.equal(expectedCmpt);
+    expect(fn(site, true)(cmptJson)).to.equal(expectedCmpt);
   });
 
   it('does not affect non-component reference properties', function () {
-    expect(JSON.parse(fn(cmptJson, site)).image).to.equal('http://domain.com/path/some-img.png');
+    expect(JSON.parse(fn(site, true)(cmptJson)).image).to.equal('http://domain.com/path/some-img.png');
   });
 });

--- a/lib/jsonSlugToPrefix/index.test.js
+++ b/lib/jsonSlugToPrefix/index.test.js
@@ -65,4 +65,14 @@ describe('jsonSlugToPrefix', () => {
   it('does not affect non-component reference properties', function () {
     expect(JSON.parse(fn(site, true)(cmptJson)).image).to.equal('http://domain.com/path/some-img.png');
   });
+
+  it('works when no path is defined', function () {
+    var newSite = {
+      slug: 'domain',
+      host: 'domain.com'
+    };
+
+    expect(JSON.parse(fn(newSite)(pageJson)).url).to.equal('http://domain.com/path/foobarbaz.html');
+    expect(JSON.parse(fn(newSite, true)(cmptJson)).image).to.equal('http://domain.com/path/some-img.png');
+  });
 });

--- a/lib/uriPrefixToSlug/README.md
+++ b/lib/uriPrefixToSlug/README.md
@@ -1,0 +1,26 @@
+### uriPrefixToSlug
+
+Replace the site prefix with the site's slug for a given uri
+
+#### Params
+
+* `uri` _string_
+* `site` _object_
+
+**Returns** _string_
+
+#### Example
+
+```js
+uriPrefixToSlug('domain.com/path/_components/foo/instances/foo@published', locals.site);
+//=> 'domain/_components/foo/instances/foo@published'
+
+uriPrefixToSlug('domain.com/path/_pages/foo', locals.site);
+//=> 'domain/_pages/foo'
+
+uriPrefixToSlug('domain.com/path/_lists/foo', locals.site);
+//=> 'domain/_lists/foo'
+
+uriPrefixToSlug('domain.com/path/_uris/foo', locals.site);
+//=> 'domain/_uris/foo'
+```

--- a/lib/uriPrefixToSlug/index.js
+++ b/lib/uriPrefixToSlug/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const isUriStringCheck = require('../strCheck');
+
+/**
+ * Remove the url-patterned prefix for the site's slug.
+ *
+ * @param  {String} uri
+ * @param  {Object} site
+ * @return {String}
+ */
+module.exports = function (uri, site) {
+  var { host, path, slug } = site;
+
+  isUriStringCheck.strCheck(uri);
+  return uri.replace(path && path.length > 1 ? `${host}${path}` : host, slug);
+};

--- a/lib/uriPrefixToSlug/index.test.js
+++ b/lib/uriPrefixToSlug/index.test.js
@@ -26,6 +26,16 @@ describe('uriPrefixToSlug', () => {
     expect(fn('domain.com/_uris/foo', site)).to.equal('domain/_uris/foo');
   });
 
+  it('works with the site path too', () => {
+    const newSite = JSON.parse(JSON.stringify(site)); // quick clone
+
+    newSite.path = '/path';
+    expect(fn('domain.com/path/_lists/foo', newSite)).to.equal('domain/_lists/foo');
+    expect(fn('domain.com/path/_components/foo/instances/bar', newSite)).to.equal('domain/_components/foo/instances/bar');
+    expect(fn('domain.com/path/_pages/foo', newSite)).to.equal('domain/_pages/foo');
+    expect(fn('domain.com/path/_uris/foo', newSite)).to.equal('domain/_uris/foo');
+  });
+
   it('throws an error if the URI passed in is not a string', () => {
     const nonStringArgument = function () {
       return fn([0, 1, 2, 3]);

--- a/lib/uriPrefixToSlug/index.test.js
+++ b/lib/uriPrefixToSlug/index.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const name = __filename.split('/').pop().split('.').shift(),
+  fn = require('./' + name),
+  expect = require('chai').expect,
+  site = {
+    slug: 'domain',
+    host: 'domain.com',
+    path: '/'
+  };
+
+describe('uriPrefixToSlug', () => {
+  it('swaps the site prefix for the site slug for lists', () => {
+    expect(fn('domain.com/_lists/foo', site)).to.equal('domain/_lists/foo');
+  });
+
+  it('swaps the site prefix for the site slug for components', () => {
+    expect(fn('domain.com/_components/foo/instances/bar', site)).to.equal('domain/_components/foo/instances/bar');
+  });
+
+  it('swaps the site prefix for the site slug for pages', () => {
+    expect(fn('domain.com/_pages/foo', site)).to.equal('domain/_pages/foo');
+  });
+
+  it('swaps the site prefix for the site slug for uris', () => {
+    expect(fn('domain.com/_uris/foo', site)).to.equal('domain/_uris/foo');
+  });
+
+  it('throws an error if the URI passed in is not a string', () => {
+    const nonStringArgument = function () {
+      return fn([0, 1, 2, 3]);
+    };
+
+    expect(nonStringArgument).to.throw(Error);
+  });
+});

--- a/lib/uriSlugToPrefix/README.md
+++ b/lib/uriSlugToPrefix/README.md
@@ -1,0 +1,26 @@
+### uriPrefixToSlug
+
+Replace the site slug with the site's prefix for a given uri
+
+#### Params
+
+* `uri` _string_
+* `site` _object_
+
+**Returns** _string_
+
+#### Example
+
+```js
+uriPrefixToSlug('domain/_components/foo/instances/foo@published', locals.site);
+//=> 'domain.com/path/_components/foo/instances/foo@published'
+
+uriPrefixToSlug('domain/_pages/foo', locals.site);
+//=> 'domain.com/path/_pages/foo'
+
+uriPrefixToSlug('domain/_lists/foo', locals.site);
+//=> 'domain.com/path/_lists/foo'
+
+uriPrefixToSlug('domain/_uris/foo', locals.site);
+//=> 'domain.com/path/_uris/foo'
+```

--- a/lib/uriSlugToPrefix/index.js
+++ b/lib/uriSlugToPrefix/index.js
@@ -3,17 +3,16 @@
 const isUriStringCheck = require('../strCheck');
 
 /**
- * Remove the url-patterned prefix for the site's slug.
+ * Remove the site's slug for the url-patterned prefix
  *
  * @param  {String} uri
  * @param  {Object} site
  * @return {String}
  */
 module.exports = function (uri, site) {
-  var { host, path, slug, prefix } = site;
+  var { slug, prefix, host, path } = site;
 
   prefix = prefix || path && path.length > 1 ? `${host}${path}` : host;
-
   isUriStringCheck.strCheck(uri);
-  return uri.replace(prefix, slug);
+  return uri.replace(slug, prefix);
 };

--- a/lib/uriSlugToPrefix/index.test.js
+++ b/lib/uriSlugToPrefix/index.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const name = __filename.split('/').pop().split('.').shift(),
+  fn = require('./' + name),
+  expect = require('chai').expect,
+  site = {
+    slug: 'domain',
+    host: 'domain.com',
+    path: '/path'
+  };
+
+describe('uriSlugToPrefix', () => {
+  it('swaps the site prefix for the site slug for lists', () => {
+    expect(fn('domain/_lists/foo', site)).to.equal('domain.com/path/_lists/foo');
+  });
+
+  it('swaps the site prefix for the site slug for components', () => {
+    expect(fn('domain/_components/foo/instances/bar', site)).to.equal('domain.com/path/_components/foo/instances/bar');
+  });
+
+  it('swaps the site prefix for the site slug for pages', () => {
+    expect(fn('domain/_pages/foo', site)).to.equal('domain.com/path/_pages/foo');
+  });
+
+  it('swaps the site prefix for the site slug for uris', () => {
+    expect(fn('domain/_uris/foo', site)).to.equal('domain.com/path/_uris/foo');
+  });
+
+  it('works with the site prefix too', () => {
+    site.prefix = 'domain.com/path';
+    expect(fn('domain/_lists/foo', site)).to.equal('domain.com/path/_lists/foo');
+    expect(fn('domain/_components/foo/instances/bar', site)).to.equal('domain.com/path/_components/foo/instances/bar');
+    expect(fn('domain/_pages/foo', site)).to.equal('domain.com/path/_pages/foo');
+    expect(fn('domain/_uris/foo', site)).to.equal('domain.com/path/_uris/foo');
+  });
+
+  it('if no path, uses just the host', () => {
+    const siteWithNoPath = {
+      slug: 'domain',
+      host: 'domain.com'
+    };
+
+    expect(fn('domain/_lists/foo', siteWithNoPath)).to.equal('domain.com/_lists/foo');
+    expect(fn('domain/_components/foo/instances/bar', siteWithNoPath)).to.equal('domain.com/_components/foo/instances/bar');
+    expect(fn('domain/_pages/foo', siteWithNoPath)).to.equal('domain.com/_pages/foo');
+    expect(fn('domain/_uris/foo', siteWithNoPath)).to.equal('domain.com/_uris/foo');
+  });
+
+  it('throws an error if the URI passed in is not a string', () => {
+    const nonStringArgument = function () {
+      return fn([0, 1, 2, 3]);
+    };
+
+    expect(nonStringArgument).to.throw(Error);
+  });
+});


### PR DESCRIPTION
- Underscores top-level routes (`/components` ==> `/_components`) to be compatible with new key structure
- Adds functions for modifying key prefixes when interacting with the DB.
- Bump travis to use node 8