### PR TITLE
Adds getPrefix function

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports.getComponentVersion = require('./lib/getComponentVersion');
 module.exports.getPageInstance = require('./lib/getPageInstance');
 module.exports.getPageVersion = require('./lib/getPageVersion');
 module.exports.getListInstance = require('./lib/getListInstance');
+module.exports.getPrefix = require('./lib/getPrefix');
 module.exports.isComponent = require('./lib/isComponent');
 module.exports.isDefaultComponent = require('./lib/isDefaultComponent');
 module.exports.isPage = require('./lib/isPage');

--- a/lib/getPrefix/index.js
+++ b/lib/getPrefix/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const isUriStringCheck = require('../strCheck');
+
+/**
+ * Return the site prefix from the URI.
+ * @param  {string}  uri
+ * @return {string}
+ */
+module.exports = function (uri) {
+  isUriStringCheck.strCheck(uri);
+  return uri.split(/\/_(pages|components|lists|uris|schedule|users)/)[0];
+};

--- a/lib/getPrefix/index.test.js
+++ b/lib/getPrefix/index.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const name = __filename.split('/').pop().split('.').shift(),
+  fn = require('./' + name),
+  expect = require('chai').expect;
+
+describe('getPrefix', () => {
+  it('returns site prefix of component uri', () => {
+    expect(fn('domain.com/_components/foo')).to.equal('domain.com');
+  });
+  it('returns site prefix of list uri', () => {
+    expect(fn('domain.com/_lists/foo')).to.equal('domain.com');
+  });
+  it('returns site prefix of uri uri', () => {
+    expect(fn('domain.com/_uris/foo')).to.equal('domain.com');
+  });
+  it('returns site prefix of schedule uri', () => {
+    expect(fn('domain.com/_schedule/foo')).to.equal('domain.com');
+  });
+  it('returns site prefix of user uri', () => {
+    expect(fn('domain.com/_users/foo')).to.equal('domain.com');
+  });
+  it('returns site prefix of page uri', () => {
+    expect(fn('domain.com/_pages/foo')).to.equal('domain.com');
+  });
+  it('works with site with path', () => {
+    expect(fn('domain.com/a/b/_pages/foo')).to.equal('domain.com/a/b');
+  });
+  it('throws an error if the URI passed in is not a string', () => {
+    expect(() => fn([0, 1, 2, 3])).to.throw(Error);
+  });
+});


### PR DESCRIPTION
`getPrefix` will return the site prefix of a URI -- e.g. `domain.com/a/b/_components/c/instances/d` will return `domain.com/a/b`.