### PR TITLE
Update getPageInstance function to support meta endpoint of a page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
-# Webstorm
+# WebStorm
 .idea

--- a/lib/getComponentInstance/index.js
+++ b/lib/getComponentInstance/index.js
@@ -11,7 +11,7 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /\/_components\/.+?\/instances\/([^\.@]+)/.exec(uri);
+  const result = /\/_components\/.+?\/instances\/([\w-]+)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getLayoutInstance/index.js
+++ b/lib/getLayoutInstance/index.js
@@ -11,7 +11,7 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /\/_layouts\/.+?\/instances\/([^\.@]+)/.exec(uri);
+  const result = /\/_layouts\/.+?\/instances\/([\w-]+)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getLayoutInstance/index.test.js
+++ b/lib/getLayoutInstance/index.test.js
@@ -6,7 +6,14 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('getLayoutInstance', () => {
   it('gets instance from uri', function () {
-    expect(fn('/_layouts/base/instances/0')).to.equal('0');
+    const uris = [
+      '/_layouts/base/instances/0',
+      '/_layouts/base/instances/0/meta'
+    ];
+
+    uris.forEach(uri => {
+      expect(fn(uri)).to.equal('0');
+    });
   });
 
   it('gets instance from uri with extension', function () {

--- a/lib/getPageInstance/README.md
+++ b/lib/getPageInstance/README.md
@@ -18,5 +18,5 @@ getPageInstance('nymag.com/scienceofus/_pages/foobar-baz/meta')
 //=> 'foobar-baz'
 
 getPageInstance('nymag.com/scienceofus/_pages/foobarbaz@published')
-//=> 'foobarbaz@published'
+//=> 'foobarbaz'
 ```

--- a/lib/getPageInstance/README.md
+++ b/lib/getPageInstance/README.md
@@ -11,7 +11,12 @@ Get page instance from uri
 #### Example
 
 ```js
+getPageInstance('nymag.com/scienceofus/_pages/foobarbaz')
+//=> 'foobarbaz'
+
+getPageInstance('nymag.com/scienceofus/_pages/foobar-baz/meta')
+//=> 'foobar-baz'
+
 getPageInstance('nymag.com/scienceofus/_pages/foobarbaz@published')
 //=> 'foobarbaz@published'
-
 ```

--- a/lib/getPageInstance/index.js
+++ b/lib/getPageInstance/index.js
@@ -4,14 +4,14 @@ const isUriStringCheck = require('../strCheck');
 
 /**
  * First test if argument passed in is a String. If true, get page instance
- * from uri that includes page version. Otherwise, throw an error.
- * @example /_pages/cj21ud3rt00wmqpyefc944hez@published returns cj21ud3rt00wmqpyefc944hez@published
+ * from uri without the page version. Otherwise, throw an error.
+ * @example /_pages/cj21ud3rt00wmqpyefc944hez@published returns cj21ud3rt00wmqpyefc944hez
  * @param  {string} uri
  * @return {string|null}
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /\/_pages\/([\w-]*(?:@published)?)/.exec(uri);
+  const result = /\/_pages\/([\w-]+)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getPageInstance/index.js
+++ b/lib/getPageInstance/index.js
@@ -11,7 +11,7 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  const result = /\/_pages\/(.*)/.exec(uri);
+  const result = /\/_pages\/([\w-]*(?:@published)?)/.exec(uri);
 
   return result && result[1];
 };

--- a/lib/getPageInstance/index.test.js
+++ b/lib/getPageInstance/index.test.js
@@ -28,11 +28,11 @@ describe('getPageInstance', () => {
   });
 
   it('gets instance from uri with version', function () {
-    expect(fn('/_pages/foobar@published')).to.equal('foobar@published');
+    expect(fn('/_pages/foobar@published')).to.equal('foobar');
   });
 
   it('gets instance from full uri', function () {
-    expect(fn('nymag.com/scienceofus/_pages/foobarbaz@published')).to.equal('foobarbaz@published');
+    expect(fn('nymag.com/scienceofus/_pages/foobarbaz@published')).to.equal('foobarbaz');
   });
 
   it('CANNOT get instance from a non-page uri', function () {

--- a/lib/getPageInstance/index.test.js
+++ b/lib/getPageInstance/index.test.js
@@ -6,7 +6,25 @@ const name = __filename.split('/').pop().split('.').shift(),
 
 describe('getPageInstance', () => {
   it('gets instance from uri', function () {
-    expect(fn('/_pages/foobar')).to.equal('foobar');
+    const uris = [
+      '/_pages/foobar',
+      '/_pages/foobar/meta'
+    ];
+
+    uris.forEach(uri => {
+      expect(fn(uri)).to.equal('foobar');
+    });
+  });
+
+  it('gets instance from uri', function () {
+    const uris = [
+      '/_pages/foobar-baz',
+      '/_pages/foobar-baz/meta'
+    ];
+
+    uris.forEach(uri => {
+      expect(fn(uri)).to.equal('foobar-baz');
+    });
   });
 
   it('gets instance from uri with version', function () {
@@ -18,7 +36,14 @@ describe('getPageInstance', () => {
   });
 
   it('CANNOT get instance from a non-page uri', function () {
-    expect(fn('/_components/base/instances/0')).to.not.equal('0');
+    const uris = [
+      '/_components/base/instances/0',
+      '/_components/base/instances/0/meta'
+    ];
+
+    uris.forEach(uri => {
+      expect(fn(uri)).to.not.equal('0');
+    });
   });
 
   it('throws an error if argument passed in is not a String', () => {


### PR DESCRIPTION
# Feature Info

Update `getPageInstance` to support `meta` endpoint on pages instances.

```js
getPageInstance('nymag.com/scienceofus/_pages/foobarbaz')
//=> 'foobarbaz'

getPageInstance('nymag.com/scienceofus/_pages/foobar-baz/meta')
//=> 'foobar-baz'

getPageInstance('nymag.com/scienceofus/_pages/foobarbaz@published')
//=> 'foobarbaz@published'
```