### PR TITLE
update getPrefix for layouts

### DIFF
--- a/lib/getPrefix/index.js
+++ b/lib/getPrefix/index.js
@@ -9,5 +9,5 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (uri) {
   isUriStringCheck.strCheck(uri);
-  return uri.split(/\/_(pages|components|lists|uris|schedule|users)/)[0];
+  return uri.split(/\/_(pages|components|lists|uris|schedule|users|layouts)/)[0];
 };

--- a/lib/getPrefix/index.test.js
+++ b/lib/getPrefix/index.test.js
@@ -23,6 +23,9 @@ describe('getPrefix', () => {
   it('returns site prefix of page uri', () => {
     expect(fn('domain.com/_pages/foo')).to.equal('domain.com');
   });
+  it('returns site prefix of layout uri', () => {
+    expect(fn('domain.com/_layouts/foo')).to.equal('domain.com');
+  });
   it('works with site with path', () => {
     expect(fn('domain.com/a/b/_pages/foo')).to.equal('domain.com/a/b');
   });


### PR DESCRIPTION
quick update for `getPrefix`, so it gets site prefixes from `/_layouts/` uris