### PR TITLE
remove destructuring usages

### DIFF
--- a/lib/jsonPrefixToSlug/index.js
+++ b/lib/jsonPrefixToSlug/index.js
@@ -12,7 +12,10 @@ const isUriStringCheck = require('../strCheck');
  * @return {String}
  */
 module.exports = function (json, site, ref = false) {
-  var { slug, host, path, prefix } = site,
+  var slug = site.slug,
+    host = site.host,
+    path = site.path,
+    prefix = site.prefix,
     prefixString, replaceString, searchRegex;
 
   isUriStringCheck.strCheck(json);

--- a/lib/jsonSlugToPrefix/index.js
+++ b/lib/jsonSlugToPrefix/index.js
@@ -12,7 +12,10 @@ const isUriStringCheck = require('../strCheck');
  */
 module.exports = function (site, ref = false) {
   return function (json) {
-    var { slug, host, path, prefix } = site,
+    var slug = site.slug,
+      host = site.host,
+      path = site.path,
+      prefix = site.prefix,
       prefixString, searchString, searchRegex;
 
     isUriStringCheck.strCheck(json);

--- a/lib/uriPrefixToSlug/index.js
+++ b/lib/uriPrefixToSlug/index.js
@@ -10,7 +10,10 @@ const isUriStringCheck = require('../strCheck');
  * @return {String}
  */
 module.exports = function (uri, site) {
-  var { host, path, slug, prefix } = site,
+  var slug = site.slug,
+    host = site.host,
+    path = site.path,
+    prefix = site.prefix,
     hasSlash = uri.indexOf('/_') !== -1;
 
   if (!prefix) {

--- a/lib/uriSlugToPrefix/index.js
+++ b/lib/uriSlugToPrefix/index.js
@@ -10,7 +10,10 @@ const isUriStringCheck = require('../strCheck');
  * @return {String}
  */
 module.exports = function (uri, site) {
-  var { slug, prefix, host, path } = site,
+  var slug = site.slug,
+    host = site.host,
+    path = site.path,
+    prefix = site.prefix,
     hasSlash = uri.indexOf('/_') !== -1;
 
   if (!prefix) {


### PR DESCRIPTION
Keeping the code free of destructuring and other ES6 syntax allows this module to be used client-side without having to make changes to claycli to force browserify to transform this module.